### PR TITLE
Avoid infinite recursion on unsupported Lisps

### DIFF
--- a/utils-kt.asd
+++ b/utils-kt.asd
@@ -6,7 +6,8 @@
 ;;;(operate 'load-op :asdf-aclproj)
 ;;;(use-package :asdf-aclproj)
 
-#+(or allegro lispworks cmu mcl clisp cormanlisp sbcl scl abcl)
+#-(or allegro lispworks cmu mcl clisp cormanlisp sbcl scl abcl)
+(error "Your implementation, ~S, is not supported" (lisp-implementation-type))
 
 (asdf:defsystem :utils-kt
   :name "utils-kt"


### PR DESCRIPTION
When a Lisp isn't in the supported list, the system file still tries to add a method to ASDF:PERFORM. The (find-system :utils-kt) in the lambda list then recursively calls find-system, fails to find the undefined utils-kt, and loads utils-kt.asd again, invoking defmethod again, ad infinitum (or until it blows the stack).

This change signals an error on unsupported Lisps instead.