### PR TITLE
portability fixes

### DIFF
--- a/defpackage.lisp
+++ b/defpackage.lisp
@@ -36,8 +36,8 @@
 (defpackage :utils-kt
   (:nicknames #:ukt)
   (:use #:common-lisp
-    #+(or allegro lispworks clisp) #:clos
-    #+cmu  #:mop
+    #+(or allegro lispworks clisp scl ecl) #:clos
+    #+(or cmu abcl)  #:mop
     #+sbcl #:sb-mop
     #+openmcl-partial-mop #:openmcl-mop
     #+(and mcl (not openmcl-partial-mop))  #:ccl)

--- a/detritus.lisp
+++ b/detritus.lisp
@@ -40,8 +40,7 @@ See the Lisp Lesser GNU Public License for more details.
     ;; all this was conditional on c being found, but if it isn't the find-class errors as coded so
     ;; let's take out the meaningless condition and see what happens
     (finalize-inheritance cc)
-    #-sbcl(mop::class-prototype cc)
-    #+sbcl(sb-mop:class-prototype cc)))
+    (class-prototype cc)))
 
 (defun brk (&rest args)
   #+its-alive! (apply 'error args)

--- a/utils-kt.asd
+++ b/utils-kt.asd
@@ -6,7 +6,7 @@
 ;;;(operate 'load-op :asdf-aclproj)
 ;;;(use-package :asdf-aclproj)
 
-#-(or allegro lispworks cmu mcl clisp cormanlisp sbcl scl ecl abcl)
+#-(or allegro lispworks cmu mcl ccl clisp cormanlisp sbcl scl ecl abcl)
 (error "Your implementation, ~S, is not supported" (lisp-implementation-type))
 
 (asdf:defsystem :utils-kt

--- a/utils-kt.asd
+++ b/utils-kt.asd
@@ -6,7 +6,7 @@
 ;;;(operate 'load-op :asdf-aclproj)
 ;;;(use-package :asdf-aclproj)
 
-#-(or allegro lispworks cmu mcl clisp cormanlisp sbcl scl abcl)
+#-(or allegro lispworks cmu mcl clisp cormanlisp sbcl scl ecl abcl)
 (error "Your implementation, ~S, is not supported" (lisp-implementation-type))
 
 (asdf:defsystem :utils-kt


### PR DESCRIPTION
This adds support for ECL and CCL and slighly simplifies detritus.lisp - package is already imported by defpackage, so no need to explicitly ifdef stuff.